### PR TITLE
Add MPI support

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,8 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_:
-        CONFIG: linux_
+      linux_64_:
+        CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
     maxParallel: 8

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,8 +8,8 @@ jobs:
     vmImage: macOS-10.14
   strategy:
     matrix:
-      osx_:
-        CONFIG: osx_
+      osx_64_:
+        CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
     maxParallel: 8
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -16,3 +16,5 @@ libblas:
 - 3.8 *netlib
 liblapack:
 - 3.8.0 *netlib
+target_platform:
+- linux-64

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -22,3 +22,5 @@ libblas:
 - 3.8 *netlib
 liblapack:
 - 3.8.0 *netlib
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -16,3 +16,5 @@ libblas:
 - 3.8 *netlib
 liblapack:
 - 3.8.0 *netlib
+target_platform:
+- linux-ppc64le

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -20,3 +20,5 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+target_platform:
+- osx-64

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2019, conda-forge
+Copyright (c) 2015-2020, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux</td>
+              <td>linux_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10334&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dftbplus-feedstock?branchName=master&jobName=linux&configuration=linux_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dftbplus-feedstock?branchName=master&jobName=linux&configuration=linux_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -64,22 +64,16 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx</td>
+              <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10334&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dftbplus-feedstock?branchName=master&jobName=osx&configuration=osx_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dftbplus-feedstock?branchName=master&jobName=osx&configuration=osx_64_" alt="variant">
                 </a>
               </td>
             </tr>
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>Windows</td>
-    <td>
-      <img src="https://img.shields.io/badge/Windows-disabled-lightgrey.svg" alt="Windows disabled">
     </td>
   </tr>
 </table>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,10 +3,8 @@ set -ex
 
 if [ "${mpi}" != "nompi" ]; then
   MPI=ON
-  LAPACK_LIBRARIES="'lapack;blas;scalapack'"
 else
   MPI=OFF
-  LAPACK_LIBRARIES="'lapack;blas'"
 fi
 
 cmake_options=(
@@ -14,7 +12,8 @@ cmake_options=(
    "-DCMAKE_BUILD_TYPE=Release"
    "-DCMAKE_INSTALL_PREFIX=${PREFIX}"
    "-DBUILD_SHARED_LIBS=ON"
-   "-DLAPACK_LIBRARIES=${LAPACK_LIBRARIES}"
+   "-DLAPACK_LIBRARIES='lapack;blas'"
+   "-DSCALAPACK_LIBRARIES='scalapack'"
    "-DWITH_API=ON"
    "-DWITH_SOCKETS=ON"
    "-DWITH_OMP=ON"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
 set -ex
 
+if [ "${mpi}" != "nompi" ]; then
+  MPI=ON
+  LAPACK_LIBRARIES="'lapack;blas;scalapack'"
+else
+  MPI=OFF
+  LAPACK_LIBRARIES="'lapack;blas'"
+fi
+
 cmake_options=(
    "-GNinja"
    "-DCMAKE_BUILD_TYPE=Release"
    "-DCMAKE_INSTALL_PREFIX=${PREFIX}"
    "-DBUILD_SHARED_LIBS=ON"
-   "-DLAPACK_LIBRARIES='lapack;blas'"
+   "-DLAPACK_LIBRARIES=${LAPACK_LIBRARIES}"
    "-DWITH_API=ON"
    "-DWITH_SOCKETS=ON"
    "-DWITH_OMP=ON"
-   "-DWITH_MPI=OFF"
+   "-DWITH_MPI=${MPI}"
    ".."
 )
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,7 @@
+mpi:
+  - nompi
+  - mpich
+  - openmpi
+pin_run_as_build:
+  mpich: x.x
+  openmpi: x.x 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ source:
   - url: https://github.com/{{ name }}/scalapackfx/archive/{{ name }}-{{ version }}.tar.gz
     sha256: 23797a2ac8c495a4bd9cc9445f14a8aca7eee0ce585f86b9e575b1e2a4b68cb6
     folder: "external/scalapackfx/origin"
+    patches:
+    - scalapack-link.patch
   {% endif %}
 
 {% if mpi == "nompi" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,7 @@ test:
   requires:
     - pkg-config
   commands:
-    - pkg-config --modversion {{ name }} --exact-version {{ version }}
+    - pkg-config {{ name }} --exact-version {{ version }}
     - test -f $PREFIX/bin/dftb+
     - test -f $PREFIX/lib/libdftbplus.dylib  # [osx]
     - test -f $PREFIX/lib/libdftbplus.so  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,44 @@
 {% set name = "dftbplus" %}
 {% set version = "20.1" %}
+{% set build = 1 %}
+{% set mpi = mpi or "nompi" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: a155ca927c804234587c61c4938d154f31578c816b0ce20eaee3b5d7e39d91dc
-  patches:
+  - url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
+    sha256: a155ca927c804234587c61c4938d154f31578c816b0ce20eaee3b5d7e39d91dc
+    patches:
     - no-python.patch
+  {% if mpi != "nompi" %}
+  - url: https://github.com/{{ name }}/mpifx/archive/{{ name }}-{{ version }}.tar.gz
+    sha256: 321808573bc7f7719a34516723bd9514ddb6db508a74b572a52794f7bc864f93
+    folder: "external/mpifx/origin"
+  - url: https://github.com/{{ name }}/scalapackfx/archive/{{ name }}-{{ version }}.tar.gz
+    sha256: 23797a2ac8c495a4bd9cc9445f14a8aca7eee0ce585f86b9e575b1e2a4b68cb6
+    folder: "external/scalapackfx/origin"
+  {% endif %}
 
+{% if mpi == "nompi" %}
+{% set build = build + 100 %}
+{% endif %}
 build:
-  number: 0
+  number: {{ build }}
   skip: True  # [win]
+
+  {% if mpi != "nompi" %}
+  {% set mpi_prefix = "mpi_" + mpi %}
+  {% else %}
+  {% set mpi_prefix = "nompi" %}
+  {% endif %}
+  string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
+
+  {% if mpi != "nompi" %}
+  run_exports:
+    - {{ name }} * {{ mpi_prefix }}_*
+  {% endif %}
 
 requirements:
   build:
@@ -23,11 +48,15 @@ requirements:
     - ninja
     - fypp
   host:
+    - {{ mpi }}  # [mpi != "nompi"]
+    - scalapack  # [mpi != "nompi"]
     - libblas
     - liblapack
     - llvm-openmp  # [osx]
     - libgomp  # [linux and not aarch64]
   run:
+    - {{ mpi }}  # [mpi != "nompi"]
+    - scalapack  # [mpi != "nompi"]
     - libblas
     - liblapack
 
@@ -49,6 +78,8 @@ about:
     - "external/fsockets/LICENSE"
     - "external/mudpack/LICENSE"
     - "external/xmlf90/LICENSE"
+    - "external/mpifx/origin/LICENSE"  # [mpi != "nompi"]
+    - "external/scalapackfx/origin/LICENSE"  # [mpi != "nompi"]
   summary: "DFTB+ general package for performing fast atomistic simulations"
   doc_url: https://{{ name }}-recipes.readthedocs.io
   dev_url: https://github.com/{{ name }}/{{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
     sha256: a155ca927c804234587c61c4938d154f31578c816b0ce20eaee3b5d7e39d91dc
     patches:
     - no-python.patch
+    - pkg-config.patch
+    - scalapackfx.patch
   {% if mpi != "nompi" %}
   - url: https://github.com/{{ name }}/mpifx/archive/{{ name }}-{{ version }}.tar.gz
     sha256: 321808573bc7f7719a34516723bd9514ddb6db508a74b572a52794f7bc864f93
@@ -64,7 +66,10 @@ requirements:
 
 
 test:
+  requires:
+    - pkg-config
   commands:
+    - pkg-config --modversion {{ name }} --exact-version {{ version }}
     - test -f $PREFIX/bin/dftb+
     - test -f $PREFIX/lib/libdftbplus.dylib  # [osx]
     - test -f $PREFIX/lib/libdftbplus.so  # [linux]

--- a/recipe/pkg-config.patch
+++ b/recipe/pkg-config.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d2cb96cc1..2d7bbfcd4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ cmake_minimum_required(VERSION 3.5)
+ cmake_policy(VERSION 3.5)
+ 
+-set(DFTBPLUS_VERSION "19.2")
++set(DFTBPLUS_VERSION "20.1")
+ 
+ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+ include(dftbpUtils)
+diff --git a/doc/api/doxygen/Doxyfile b/doc/api/doxygen/Doxyfile
+index 098425949..320e77d88 100644
+--- a/doc/api/doxygen/Doxyfile
++++ b/doc/api/doxygen/Doxyfile
+@@ -38,7 +38,7 @@ PROJECT_NAME           = DFTB+API
+ # could be handy for archiving the generated documentation or if some version
+ # control system is used.
+ 
+-PROJECT_NUMBER         = 19.1
++PROJECT_NUMBER         = 20.1
+ 
+ # Using the PROJECT_BRIEF tag one can provide an optional one line description
+ # for a project that appears at the top of each page and should give viewer a
+

--- a/recipe/scalapack-link.patch
+++ b/recipe/scalapack-link.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index e135098..10141ca 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -27,6 +27,7 @@ foreach(fppsrc IN LISTS sources-fpp)
+ endforeach()
+ 
+ add_library(scalapackfx ${SOURCES-F90-PREPROC})
++target_link_libraries(scalapackfx ${EXTERNAL_LIBRARIES} ${MPI_Fortran_LIBRARIES})
+ 
+ set(BUILD_MOD_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
+ 

--- a/recipe/scalapackfx.patch
+++ b/recipe/scalapackfx.patch
@@ -1,0 +1,10 @@
+diff --git a/external/scalapackfx/CMakeLists.txt b/external/scalapackfx/CMakeLists.txt
+index 5ccb19b6..ca7b731a 100644
+--- a/external/scalapackfx/CMakeLists.txt
++++ b/external/scalapackfx/CMakeLists.txt
+@@ -1,4 +1,5 @@
+ set(LIBRARY_ONLY TRUE)
++set(EXTERNAL_LIBRARIES "${SCALAPACK_LIBRARIES};${LAPACK_LIBRARIES}")
+ set(INSTALL_EXPORT_NAME dftbplus-targets)
+ add_subdirectory(origin)
+ set(EXPORTED_COMPILED_LIBRARIES ${EXPORTED_COMPILED_LIBRARIES} scalapackfx PARENT_SCOPE)


### PR DESCRIPTION
MNT: Re-rendered with conda-build 3.18.11, conda-smithy 3.7.5, and conda-forge-pinning 2020.08.02.15.39.57

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* ~Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
OSX failure for MPI build due to https://github.com/dftbplus/scalapackfx/issues/22 is patched
